### PR TITLE
Update .rubocop.yml instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,8 @@ gem 'optimum-energy-rubocop'
 Create a `.rubocop.yml` file and add this configuration.
 
 ```
-require:
-  - optimum-energy-rubocop
-
-inherit_from:
-  - optimum_energy_rubocop.yml
+inherit_gem:
+  optimum-energy-rubocop: optimum_energy_rubocop.yml
 ```
 
 ## Updating This Gem


### PR DESCRIPTION
Previous instructions threw errors for me when I attempted to copy and paste the config into a new `.rubocop.yml`. These new instructions will allow someone to get started with the gem without troubleshooting install steps. 